### PR TITLE
Update METAR parsing to allow minimum visibility without direction

### DIFF
--- a/iwxxm3Converter/src/main/java/org/gamc/spmi/iwxxmConverter/marshallers/v3/METARConverterV3.java
+++ b/iwxxm3Converter/src/main/java/org/gamc/spmi/iwxxmConverter/marshallers/v3/METARConverterV3.java
@@ -649,14 +649,16 @@ public class METARConverterV3 implements TacConverter<METARTacMessage, METARType
 					.createAerodromeHorizontalVisibilityTypeMinimumVisibility(minVis);
 			visibility.setMinimumVisibility(minV);
 
-			Double dirAngleD = translatedMetar.getCommonWeatherSection().getMinimumVisibilityDirection()
-					.getDoubleValue();
-			AngleWithNilReasonType minVisAngle = iwxxmHelpers.getOfIWXXM().createAngleWithNilReasonType();
-			minVisAngle.setValue(dirAngleD);
-			minVisAngle.setUom(ANGLE_UNITS.DEGREES.getStringValue());
-			JAXBElement<AngleWithNilReasonType> minVisDirection = iwxxmHelpers.getOfIWXXM()
-					.createAerodromeHorizontalVisibilityTypeMinimumVisibilityDirection(minVisAngle);
-			visibility.setMinimumVisibilityDirection(minVisDirection);
+			if (translatedMetar.getCommonWeatherSection().getMinimumVisibilityDirection() != null) {
+				Double dirAngleD = translatedMetar.getCommonWeatherSection().getMinimumVisibilityDirection()
+						.getDoubleValue();
+			    AngleWithNilReasonType minVisAngle = iwxxmHelpers.getOfIWXXM().createAngleWithNilReasonType();
+			    minVisAngle.setValue(dirAngleD);
+			    minVisAngle.setUom(ANGLE_UNITS.DEGREES.getStringValue());
+			    JAXBElement<AngleWithNilReasonType> minVisDirection = iwxxmHelpers.getOfIWXXM()
+			    		.createAerodromeHorizontalVisibilityTypeMinimumVisibilityDirection(minVisAngle);
+			    visibility.setMinimumVisibilityDirection(minVisDirection);
+			}
 		}
 
 		// Prevailing visibility

--- a/iwxxm3Converter/src/test/java/org/gamc/spmi/iwxxmConverter/test/v3/metar/MetarTranslationTest.java
+++ b/iwxxm3Converter/src/test/java/org/gamc/spmi/iwxxmConverter/test/v3/metar/MetarTranslationTest.java
@@ -87,6 +87,10 @@ public class MetarTranslationTest {
 	
 	String metarUS1 = "METAR KORD 170651Z 20014G23KT 10SM SCT250 24/14 A2968 RMK AO2 SLP045 T02390144=";
 	
+	String metarTACMinimumVisibilityWithDirection = "METAR WIII 232230Z 18004KT 2400 0600E OVC013 27/15 Q1014";
+	
+	String metarTACMinimumVisibilityNoDirection = "METAR WIII 232230Z 18004KT 2400 0600 OVC013 27/15 Q1014";
+	
 	
 	@Test
 	public void translateSimpleMetar() throws METARParsingException {
@@ -291,6 +295,23 @@ public class MetarTranslationTest {
 		assertFalse(metarMessage.getRunwayStateSections().get(0).getDepositDepth().isPresent());
 		
 		
+	}
+	
+	@Test
+	public void translateMinimumVisibilityWithDirection() throws METARParsingException {
+		METARTacMessage metarMessage = new METARTacMessage(metarTACMinimumVisibilityWithDirection);
+		metarMessage.parseMessage();
+		assertEquals(600,metarMessage.getCommonWeatherSection().getMinimumVisibility().intValue());
+		assertEquals("E",metarMessage.getCommonWeatherSection().getMinimumVisibilityDirection().toString());
+	}
+	
+
+	@Test
+	public void translateMinimumVisibilityNoDirection() throws METARParsingException {
+		METARTacMessage metarMessage = new METARTacMessage(metarTACMinimumVisibilityNoDirection);
+		metarMessage.parseMessage();
+		assertEquals(600,metarMessage.getCommonWeatherSection().getMinimumVisibility().intValue());
+		assertNull(metarMessage.getCommonWeatherSection().getMinimumVisibilityDirection());
 	}
 	
 }

--- a/iwxxmCore/src/main/java/org/gamc/spmi/iwxxmConverter/metarconverter/MetarCommonWeatherSection.java
+++ b/iwxxmCore/src/main/java/org/gamc/spmi/iwxxmConverter/metarconverter/MetarCommonWeatherSection.java
@@ -199,7 +199,7 @@ public class MetarCommonWeatherSection implements CommonWeatherSection {
 			String sMVd = matcher.group("visibilityDirection");
 			if (sMv != null)
 				this.setMinimumVisibility(Integer.valueOf(sMv));
-			if (sMVd != null)
+			if (sMVd != null && !sMVd.isEmpty())
 				this.setMinimumVisibilityDirection(RUMB_UNITS.valueOf(sMVd));
 
 			lastIndex = matcher.end();


### PR DESCRIPTION
This updates the METAR parsing to allow minimum visibility without a direction in the METAR and IWXXM output.  Without this patch, the parsing will throw an exception when it tries to convert an empty string to an RUMB_UNITS enum.  Two tests were added to verify both direction and directionless minimum visibility converts successfully.